### PR TITLE
Fix trailing whitespaces for values on newlines in README

### DIFF
--- a/home_assistant_config_validator/models/readme_entity.py
+++ b/home_assistant_config_validator/models/readme_entity.py
@@ -115,7 +115,12 @@ class ReadmeEntity:
                 code=(key.endswith("ID") or key.casefold() == "command"),
             )
 
-            yield f"- {key}: {val!s}"
+            if val.startswith("\n"):
+                yield f"- {key}:"
+                yield val.lstrip()
+            else:
+                yield f"- {key}: {val!s}"
+
         yield f"  File: {self.file}"
 
     @property


### PR DESCRIPTION

- 73412ca | Fix trainling whitespaces for values on newlines in README
