### PR TITLE
Exclude null values from README by default

### DIFF
--- a/home_assistant_config_validator/models/config/documentation.py
+++ b/home_assistant_config_validator/models/config/documentation.py
@@ -35,6 +35,10 @@ class DocumentationConfig(Config):
     name: str = Field(default="name")
     id: str | list[str] = Field(default="id")
 
+    include_nulls: bool = Field(
+        default=False, description="Whether to include fields which have no value."
+    )
+
     extra: list[JSONPathStr] = Field(default_factory=list)
 
     def get_description(self, entity: Entity, /) -> str:

--- a/home_assistant_config_validator/models/config/documentation.py
+++ b/home_assistant_config_validator/models/config/documentation.py
@@ -36,7 +36,8 @@ class DocumentationConfig(Config):
     id: str | list[str] = Field(default="id")
 
     include_nulls: bool = Field(
-        default=False, description="Whether to include fields which have no value."
+        default=False,
+        description="Whether to include fields which have no value.",
     )
 
     extra: list[JSONPathStr] = Field(default_factory=list)

--- a/home_assistant_config_validator/models/config/validation.py
+++ b/home_assistant_config_validator/models/config/validation.py
@@ -343,7 +343,8 @@ class ValidationConfig(Config):
     )
 
     invalid_template_variables: Annotated[
-        bool, Field(deprecated="This has been replaced by the `disable` field")
+        bool,
+        Field(deprecated="This has been replaced by the `disable` field"),
     ] = False
 
     def model_post_init(self, *_: Any, **__: Any) -> None:

--- a/home_assistant_config_validator/models/readme_entity.py
+++ b/home_assistant_config_validator/models/readme_entity.py
@@ -108,7 +108,8 @@ class ReadmeEntity:
             )
 
             if not (val := get_json_value(self.entity, field, default=None)):
-                yield f"- {key}:"
+                if self.docs_config.include_nulls:
+                    yield f"- {key}:"
                 continue
 
             if isinstance(val, Secret):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,6 @@ lint.select = [
 ]
 lint.ignore = [
   "ISC001", # https://docs.astral.sh/ruff/rules/single-line-implicit-string-concatenation/
-  "COM812", # https://docs.astral.sh/ruff/rules/missing-trailing-comma/
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
- **Exclude null values from README by default**
- **Formatting**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to include fields with no value in the documentation.
  
- **Improvements**
  - Updated validation configuration with deprecation information for better clarity.

- **Bug Fixes**
  - Enhanced field generation logic to respect new documentation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->